### PR TITLE
Update threejs.scala

### DIFF
--- a/facade/src/main/scala/org/denigma/threejs/threejs.scala
+++ b/facade/src/main/scala/org/denigma/threejs/threejs.scala
@@ -10,7 +10,7 @@ import scala.scalajs.js.typedarray._
 trait WebGLRenderingContext extends js.Object {
 }
 
-package object THREE extends js.Object {
+object THREE extends js.Object {
   var REVISION: String = js.native
   var CullFaceNone: CullFace = js.native
   var CullFaceBack: CullFace = js.native


### PR DESCRIPTION
According to https://github.com/scala-js/scala-js/issues/2117 package objects in Scala.js are not designed to be used in facades.
